### PR TITLE
Update references for DLL (Server/Client)

### DIFF
--- a/source/SaltyClient/SaltyClient.csproj
+++ b/source/SaltyClient/SaltyClient.csproj
@@ -18,10 +18,10 @@
 
   <ItemGroup>
     <Reference Include="Newtonsoft.Json">
-      <HintPath>C:\Program Files (x86)\RAGEMP\dotnet\Newtonsoft.Json.dll</HintPath>
+      <HintPath>C:\RAGEMP\dotnet\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="rage-sharp">
-      <HintPath>C:\Program Files (x86)\RAGEMP\dotnet\rage-sharp.dll</HintPath>
+      <HintPath>C:\RAGEMP\dotnet\rage-sharp.dll</HintPath>
     </Reference>
   </ItemGroup>
 

--- a/source/SaltyServer/SaltyServer.csproj
+++ b/source/SaltyServer/SaltyServer.csproj
@@ -20,10 +20,10 @@
 
   <ItemGroup>
     <Reference Include="Bootstrapper">
-      <HintPath>..\..\..\..\..\Program Files (x86)\RAGEMP\server-files\dotnet\runtime\Bootstrapper.dll</HintPath>
+      <HintPath>C:\RAGEMP\server-files\dotnet\runtime\Bootstrapper.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json">
-      <HintPath>..\..\..\..\..\Program Files (x86)\RAGEMP\server-files\dotnet\runtime\Newtonsoft.Json.dll</HintPath>
+      <HintPath>C:\RAGEMP\server-files\dotnet\runtime\Newtonsoft.Json.dll</HintPath>
     </Reference>
   </ItemGroup>
 


### PR DESCRIPTION
Since RageMP installs at the root of the main drive, references to DLLs are no longer good